### PR TITLE
Fix logo and logo text not being centered in home view

### DIFF
--- a/IDesign/IDesign.Extension/ViewModels/MainViewModel.cs
+++ b/IDesign/IDesign.Extension/ViewModels/MainViewModel.cs
@@ -31,7 +31,7 @@ namespace IDesign.Extension.ViewModels
         public Visibility BackButtonVisibility
         {
             get => CurrentViewModel.GetType() == typeof(HomeViewModel)
-                ? Visibility.Hidden
+                ? Visibility.Collapsed
                 : Visibility.Visible;
         }
 

--- a/IDesign/IDesign.Extension/Views/HomeView.xaml
+++ b/IDesign/IDesign.Extension/Views/HomeView.xaml
@@ -7,8 +7,7 @@
              xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
              mc:Ignorable="d"
              d:DesignHeight="360"
-             d:DesignWidth="300"
-             SizeChanged="HomeView_OnSizeChanged">
+             d:DesignWidth="300">
     <UserControl.Resources>
         <ResourceDictionary>
             <Style TargetType="TextBlock">
@@ -66,7 +65,6 @@
         </Grid.RowDefinitions>
 
         <StackPanel Grid.Row="0"
-                    Name="ButtonsPanel"
                     HorizontalAlignment="Center"
                     Orientation="Vertical">
             <StackPanel Margin="20,20,20,0">

--- a/IDesign/IDesign.Extension/Views/HomeView.xaml.cs
+++ b/IDesign/IDesign.Extension/Views/HomeView.xaml.cs
@@ -17,10 +17,6 @@ namespace IDesign.Extension.Views
             InitializeComponent();
         }
 
-        private void HomeView_OnSizeChanged(object sender, SizeChangedEventArgs e)
-        {
-            ButtonsPanel.Orientation = e.NewSize.Width >= ButtonsPanel.Children.Count*190 ? Orientation.Horizontal : Orientation.Vertical;
-        }
         public void OnSettingsClickEvent(object sender, RoutedEventArgs e)
         {
             ThreadHelper.ThrowIfNotOnUIThread();


### PR DESCRIPTION
Changed visibility of back button in home view to Collapsed instead of Hidden so it doesn't mess up the xaml flow.

Removed the orientation of the buttons in the home view changing on window size as it doesn't work anymore because of the global scrollviewer